### PR TITLE
[feat] 한 줄 소개 빈칸으로 수정 시 None이 아닌 ' ' 형태로 수정, 친구 달력 조회 시 공개 여부 추가

### DIFF
--- a/moodoodleBack/moodoodle/friend/views.py
+++ b/moodoodleBack/moodoodle/friend/views.py
@@ -194,8 +194,11 @@ class FriendCalendarView(ListAPIView):
         return Diary.objects.filter(date__range=(start_date, end_date), user_id=to_user.user_id)
 
     def list(self, request, *args, **kwargs):
-        try:    
-            queryset = self.get_queryset()
+        to_user_id = self.kwargs.get('to_user_id')
+        to_user = users.objects.get(id=to_user_id)
+        
+        try:
+            queryset = self.get_queryset()    
             results = []
             year = int(self.kwargs.get('year'))
             month = int(self.kwargs.get('month'))
@@ -221,7 +224,8 @@ class FriendCalendarView(ListAPIView):
             response = {
                 'success': False,
                 'status_code': status.HTTP_400_BAD_REQUEST,
-                'message': str(e)
+                'message': str(e),
+                'public': to_user.public
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
@@ -229,6 +233,7 @@ class FriendCalendarView(ListAPIView):
             'success': True,
             'status_code': status.HTTP_200_OK,
             'message': '요청에 성공하였습니다.',
+            'public': to_user.public,
             'result': results
         }
         return Response(response, status=status.HTTP_200_OK)

--- a/moodoodleBack/moodoodle/user/serializers.py
+++ b/moodoodleBack/moodoodle/user/serializers.py
@@ -36,7 +36,7 @@ class MypageSerializer(serializers.ModelSerializer):
         if description:
             instance.description = description
         else:
-            instance.description = None
+            instance.description = ''
 
         public = validated_data.get('public')
         if public is not None:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our convention
- [ ] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [ ] Bugfix
- [ ] Refactor (no functional changes, no api changes)
- [ ] Design changes
- [ ] Comment added
- [ ] Code style update (formatting, local variables)
- [ ] Test code added
- [ ] Chore (other changes)
- [ ] Init
- [ ] Rename
- [ ] Remove
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
한 줄 소개를 빈칸으로 수정 시 이전에는 null로 저장이 되었음
-> ' '으로 저장하여 빈칸일 경우 아무런 메시지가 나오지 않도록 수정
친구 달력 조회 시 친구의 달력 공개 여부 public도 추가적으로 보내주도록 수정

## Does this PR introduce a breaking change?
<!-- 급격한 변화가 있는가? -->
- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
