### PR TITLE
[feat] 한 줄 소개 빈칸으로 수정 시 None이 아닌 ' '형태로 수정, 친구 목록 조회 시 달력 공개 여부 추가

### DIFF
--- a/moodoodleBack/moodoodle/friend/serializers.py
+++ b/moodoodleBack/moodoodle/friend/serializers.py
@@ -13,7 +13,7 @@ class FriendSerializer(serializers.ModelSerializer):
 class FriendListSerializer(serializers.ModelSerializer):
     class Meta:
         model = users
-        fields = ('id', 'nickname', 'profile_image', 'description')
+        fields = ('id', 'nickname', 'profile_image', 'description', 'public')
         
 class FriendRequestSerializer(serializers.ModelSerializer):
     id = serializers.CharField(source='from_user.id')

--- a/moodoodleBack/moodoodle/user/serializers.py
+++ b/moodoodleBack/moodoodle/user/serializers.py
@@ -36,7 +36,7 @@ class MypageSerializer(serializers.ModelSerializer):
         if description:
             instance.description = description
         else:
-            instance.description = None
+            instance.description = ''
 
         public = validated_data.get('public')
         if public is not None:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our convention
- [ ] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [ ] Bugfix
- [ ] Refactor (no functional changes, no api changes)
- [ ] Design changes
- [ ] Comment added
- [ ] Code style update (formatting, local variables)
- [ ] Test code added
- [ ] Chore (other changes)
- [ ] Init
- [ ] Rename
- [ ] Remove
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
기존에는 한 줄 소개를 빈칸으로 저장할 시 null이 저장이 되었음
-> ' '로 저장하여 null이 저장되는 문제 해결
친구 목록 조회 시 달력 공개 여부도 같이 보내주도록 수정

## Does this PR introduce a breaking change?
<!-- 급격한 변화가 있는가? -->
- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
